### PR TITLE
Feature/scroll explorer

### DIFF
--- a/frontend/src/panel-explorer/explorer-panelstack-view.ts
+++ b/frontend/src/panel-explorer/explorer-panelstack-view.ts
@@ -54,7 +54,9 @@ export default class PanelStackView extends View {
      * because of margins.
      */
     getRightBorderOffset(): number {
-        let widthWithoutRightMargin = this.getWidth() - ((this.getWidth() - this.getTopPanel().$el.outerWidth()) / 2);
+
+        let width = this.getWidth();
+        let widthWithoutRightMargin = width - ((width - this.getTopPanel().$el.outerWidth()) / 2);
         return this.$el.offset().left + widthWithoutRightMargin;
     }
 }

--- a/frontend/src/panel-explorer/explorer-view.ts
+++ b/frontend/src/panel-explorer/explorer-view.ts
@@ -35,7 +35,7 @@ export default class ExplorerView extends View {
         this.rltPanelStack = new Map();
         this.push(options.first);
 
-        this.$el.on('scroll', debounce(bind(this.onScroll, this), 1000));
+        this.$el.on('scroll', debounce(bind(this.onScroll, this), 500));
     }
 
     render(): View {


### PR DESCRIPTION
Closes #63 (for now). This implements the last two open things: a debounced event when scrolling and passing the `ontoPanel` in the `removeOverlay` event payload.  

@jgonggrijp : could you please have a brief look? I am particularly interested in your opinion on the implementation of the debouncing, as I use this elsewhere too (see #34). The line most in question is 38 in `explorer-view.ts`.

Many thanks!