### PR TITLE
Base annotation and item-summary-block

### DIFF
--- a/frontend/src/annotation/base-annotation-view.ts
+++ b/frontend/src/annotation/base-annotation-view.ts
@@ -1,0 +1,128 @@
+import { ViewOptions as BaseOpt } from 'backbone';
+import { extend } from 'lodash';
+import View from '../core/view';
+
+import { oa, schema, vocab, readit } from '../jsonld/ns';
+import Node from '../jsonld/node';
+import ldChannel from '../jsonld/radio';
+
+import { isType } from '../utilities/utilities';
+import SnippetView from '../utilities/snippet-view/snippet-view';
+import LabelView from '../utilities/label-view';
+
+export interface ViewOptions extends BaseOpt<Node> {
+    model: Node;
+}
+
+/**
+ * Base class for Views processing an instance of oa:Annotation
+ * and its tree of linked items. Triggers events if a certain
+ * 'endpoint' is reached. For example, ('textQuoteSelector', item) - where
+ * item is an instance of oa:TextQuoteSelector - will be triggered if
+ * such an item is found.
+ *
+ * This view subscribes itself to change events in all intermediate items,
+ * and processes them accordingly.
+ */
+export default abstract class BaseAnnotationView extends View<Node> {
+    constructor(options: ViewOptions) {
+        super(options);
+    }
+
+    render(): this {
+        return this;
+    }
+
+    baseProcessModel(annotation: Node): this {
+        let targets = annotation.get(oa.hasTarget);
+
+        if (targets) {
+            targets.forEach(n => {
+                this.baseProcessTarget(n as Node);
+                this.stopListening(n, 'change', this.baseProcessTarget);
+                this.listenTo(n, 'change', this.baseProcessTarget);
+            });
+        }
+
+        let bodies = annotation.get(oa.hasBody);
+        if (bodies) {
+            bodies.forEach(b => {
+                this.stopListening(b, 'change', this.baseProcessBody);
+                this.listenTo(b, 'change', this.baseProcessBody);
+                this.baseProcessBody(b as Node);
+            });
+        }
+
+        return this;
+    }
+
+    baseProcessTarget(target: Node): this {
+        if (isType(target, oa.SpecificResource)) {
+            let source = target.get(oa.hasSource)[0] as Node;
+            this.stopListening(source, 'change', this.baseProcessSource);
+            this.listenTo(source, 'change', this.baseProcessSource);
+            this.baseProcessSource(source);
+
+            let selectors: Node[] = target.get(oa.hasSelector) as Node[];
+            for (let selector of selectors) {
+                this.stopListening(selector, 'change', this.baseProcessSelector);
+                this.listenTo(selector, 'change', this.baseProcessSelector);
+                this.baseProcessSelector(selector);
+            }
+        }
+
+        return this;
+    }
+
+    baseProcessBody(body: Node): this {
+        if ((body.id as string).includes('ontology')) {
+            this.trigger('body:ontologyClass', body);
+        }
+        else {
+            this.trigger('body:ontologyInstance', body);
+        }
+
+        return this;
+    }
+
+    baseProcessSource(source: Node): this {
+        this.trigger('source', source);
+        return this;
+    }
+
+    baseProcessSelector(selector: Node): this {
+        if (isType(selector, oa.TextQuoteSelector)) {
+            this.trigger('textQuoteSelector', selector);
+        }
+
+        if (isType(selector, vocab('RangeSelector'))) {
+            let startSelector = selector.get(oa.hasStartSelector)[0] as Node;
+            this.stopListening(startSelector, 'change', this.baseProcessStartSelector);
+            this.listenTo(startSelector, 'change', this.baseProcessStartSelector);
+            this.baseProcessStartSelector(startSelector);
+
+            let endSelector = selector.get(oa.hasEndSelector)[0] as Node;
+            this.stopListening(endSelector, 'change', this.baseProcessEndSelector);
+            this.listenTo(endSelector, 'change', this.baseProcessEndSelector);
+            this.baseProcessEndSelector(endSelector);
+        }
+
+        return this;
+    }
+
+    baseProcessStartSelector(selector: Node): this {
+        this.trigger('startSelector', selector);
+        return this;
+    }
+
+    baseProcessEndSelector(selector: Node): this {
+        this.trigger('endSelector', selector);
+        return this;
+    }
+}
+extend(BaseAnnotationView.prototype, {
+    tagName: 'div',
+    className: 'base-annotation',
+    events: {
+    }
+});

--- a/frontend/src/utilities/item-summary-block/item-summary-block-template.hbs
+++ b/frontend/src/utilities/item-summary-block/item-summary-block-template.hbs
@@ -1,0 +1,2 @@
+<p class="title is-5">{{instanceLabel}}</p>
+<p class="subtitle is-6">({{classLabel}})</p>

--- a/frontend/src/utilities/item-summary-block/item-summary-block-view.ts
+++ b/frontend/src/utilities/item-summary-block/item-summary-block-view.ts
@@ -1,0 +1,189 @@
+import { extend, defer } from 'lodash';
+
+import { oa, rdf } from './../../jsonld/ns';
+import Node from './../../jsonld/node';
+import Graph from './../../jsonld/graph';
+import ldChannel from './../../jsonld/radio';
+import { getCssClassName, getLabel, isType, getLabelFromId } from './../utilities';
+import { getOntologyInstance, getLabelText, AnnotationPositionDetails, getPositionDetails } from '../annotation/annotation-utilities';
+
+import itemSummaryBlockTemplate from './item-summary-block-template';
+import BaseAnnotationView, { ViewOptions as BaseOpt } from '../../annotation/base-annotation-view';
+
+
+export interface ViewOptions extends BaseOpt {
+    ontology: Graph;
+}
+
+export default class ItemSummaryBlockView extends BaseAnnotationView {
+    instanceLabel: string;
+    classLabel: string;
+    cssClassName: string;
+    ontology: Graph;
+
+    /**
+     * Store if the current model is an instance of oa:Annotation
+     */
+    modelIsAnnotation: boolean;
+
+    positionDetails: AnnotationPositionDetails;
+    startSelector: Node;
+    endSelector: Node;
+    callbackFn: any;
+
+    constructor(options: ViewOptions) {
+        super(options);
+    }
+
+    initialize(options: ViewOptions): this {
+        if (!options.ontology) throw new TypeError('ontology cannot be null or undefined');
+        this.ontology = options.ontology;
+
+        this.listenTo(this, 'startSelector', this.processStartSelector);
+        this.listenTo(this, 'endSelector', this.processEndSelector);
+        this.listenTo(this, 'body:ontologyClass', this.processOntologyClass);
+        this.listenTo(this, 'body:ontologyInstance', this.processOntologyInstance);
+        this.listenTo(this.model, 'change', this.processModel);
+        this.processModel(this.model);
+        return this;
+    }
+
+    processModel(model: Node): this {
+        this.baseProcessBody(this.model);
+
+        if (model.has('@type')) {
+            this.modelIsAnnotation = isType(this.model, oa.Annotation);
+            if (this.modelIsAnnotation) {
+                this.stopListening(this, 'textQuoteSelector', this.processTextQuoteSelector);
+                this.listenTo(this, 'textQuoteSelector', this.processTextQuoteSelector);
+                this.baseProcessModel(this.model);
+            }
+            else {
+                this.stopListening(this.model, 'change', this.processItem);
+                this.listenTo(this.model, 'change', this.processItem);
+                this.processItem(this.model);
+            }
+        }
+
+        return this;
+    }
+
+    processOntologyClass(ontologyClass: Node): this {
+        if (ontologyClass.has('@type')) {
+            this.classLabel = getLabel(ontologyClass);
+            this.$el.removeClass(this.cssClassName);
+            this.cssClassName = getCssClassName(ontologyClass);
+        }
+        return this.render();
+    }
+
+    processOntologyInstance(ontologyInstance): this {
+        this.instanceLabel = getLabel(ontologyInstance);
+        this.render();
+        return this;
+    }
+
+    processItem(item: Node): this {
+        this.instanceLabel = getLabel(item);
+        if (item.has('@type')) {
+            let ontologyClass = ldChannel.request('obtain', item.get('@type')[0] as string);
+            this.processOntologyClass(ontologyClass);
+        }
+        this.render();
+        return this;
+    }
+
+    processTextQuoteSelector(selector: Node): this {
+        this.instanceLabel = getLabelText(selector);
+        this.render();
+        return this;
+    }
+
+    processStartSelector(selector: Node): this {
+        if (selector.has(rdf.value)) {
+            this.startSelector = selector;
+            this.processSelectors();
+        }
+        return this;
+    }
+
+    processEndSelector(selector: Node): this {
+        if (selector.has(rdf.value)) {
+            this.endSelector = selector;
+            this.processSelectors();
+        }
+        return this;
+    }
+
+    processSelectors(): this {
+        if (this.startSelector && this.endSelector) {
+            this.positionDetails = getPositionDetails(this.startSelector, this.endSelector);
+            if (this.callbackFn) {
+                this.callbackFn();
+                delete this.callbackFn;
+            }
+        }
+        return this;
+    }
+
+    ensurePositionDetails(callback: any): void {
+        if (this.positionDetails) {
+            defer(callback);
+        }
+        this.callbackFn = callback;
+    }
+
+    render(): this {
+        this.$el.html(this.template(this));
+        this.$el.addClass(this.cssClassName);
+        return this;
+    }
+
+    select(): this {
+        this.$el.addClass('is-highlighted');
+        return this;
+    }
+
+    unSelect(): this {
+        this.$el.removeClass('is-highlighted');
+        return this;
+    }
+
+    toggleHighlight(): this {
+        this.$el.toggleClass('is-highlighted');
+        return this;
+    }
+
+    getTop(): number {
+        return this.$el.offset().top;
+    }
+
+    getHeight(): number {
+        return this.$el.outerHeight();
+    }
+
+    onClick(): this {
+        this.trigger('click', this, this.model);
+        return this;
+    }
+
+    onHover(): this {
+        this.trigger('hover', this, this.model);
+        return this;
+    }
+
+    onHoverEnd(): this {
+        this.trigger('hoverEnd', this, this.model);
+        return this;
+    }
+}
+extend(ItemSummaryBlockView.prototype, {
+    tagName: 'span',
+    className: 'item-sum-block',
+    template: itemSummaryBlockTemplate,
+    events: {
+        'click': 'onClick',
+        'hover': 'onHover',
+        'hoverEnd': 'onHoverEnd'
+    }
+});


### PR DESCRIPTION
@jgonggrijp : this one demonstrates a principal that is fundamental to a lot of the views, namely all those that inherit from `BaseAnnotationView`. Please consider this one an example that I want you to look at in order to review mainly that principle. If need be, I will update all relevant views before submitting them for further review.

The principle I mean is the interplay between base and child view(s), and in particular the fact that they communicate with events. All child views call `this.baseProcessModel()`, which in turn will throw events for all sub`Node`s that are loaded / change subsequently. These events are then processed by the child view to do custom things with the data they receive. 

I played with abstract methods in the base class here for a while, but as you will see, not all child views need to implement methods for handling all sub`Node`s details, so I thought that was overkill.

Please do let me know what you think.

