### PR TITLE
Annnotation edit panel

### DIFF
--- a/frontend/src/annotation/panel-annotation-edit-template.hbs
+++ b/frontend/src/annotation/panel-annotation-edit-template.hbs
@@ -1,0 +1,40 @@
+<form class="anno-edit-form" method="get" action="">
+    <div class="panel-content">
+        <p class="title">Edit Annotation</p>
+        <p class="subtitle is-7">(Find more info on what and how to annotate in
+            <a class="is-link" href="http://dhstatic.hum.uu.nl/readit/AnnotationGuide.pdf" target="_blank">the Annotation Guide</a>)
+        </p>
+
+        <div class="snippet-container">
+            {{! Snippet inserted here }}
+        </div>
+
+        <fieldset>
+            <div class="field">
+                <label class="label"></label>
+                <div class="control ontology-class-picker-container">
+                    {{! Ontology class picker is inserted here }}
+                </div>
+                {{! Fake input to utilize jquery validation on Bulma dropdown}}
+                <input class="hidden-input" type="text" id="contology" required>
+            </div>
+        </fieldset>
+
+        <div class="metadata-container">
+            {{! metadata view inserted here}}
+        </div>
+        {{!-- <section class="item-sections">
+            <article class="item-section has-mt-10">
+                <div class="item-section-header">
+                    <p>Add Related item</p>
+                    <span class="btn-rel-item icon is-large has-text-primary tooltip is-tooltip-left"
+                        data-tooltip="Add related item">
+                        <i class="fas fa-arrow-circle-right"></i>
+                    </span>
+                </div>
+            </article>
+        </section> --}}
+    </div>
+    <button class="button btn-save is-pulled-right submit" type="submit">Save</button>
+    <button class="button btn-cancel is-pulled-right is-primary">Cancel</button>
+</form>

--- a/frontend/src/annotation/panel-annotation-edit.ts
+++ b/frontend/src/annotation/panel-annotation-edit.ts
@@ -1,0 +1,238 @@
+import { ViewOptions as BaseOpt } from 'backbone';
+import { extend } from 'lodash';
+
+import { oa } from '../jsonld/ns';
+import Node from '../jsonld/node';
+import Graph from '../jsonld/graph';
+import ldChannel from '../jsonld/radio';
+
+import OntologyClassPickerView from '../utilities/ontology-class-picker/ontology-class-picker-view';
+import ItemMetadataView from '../utilities/item-metadata/item-metadata-view';
+import SnippetView from '../utilities/snippet-view/snippet-view';
+import { isType } from '../utilities/utilities';
+import { getOntologyInstance, AnnotationPositionDetails } from '../utilities/annotation/annotation-utilities';
+import { composeAnnotation, getAnonymousTextQuoteSelector } from './../utilities/annotation/annotation-creation-utilities';
+
+import BaseAnnotationView from './base-annotation-view';
+
+import annotationEditTemplate from './panel-annotation-edit-template';
+
+
+export interface ViewOptions extends BaseOpt<Node> {
+    /**
+     * An instance of oa:Annotation that links to a oa:TextQuoteSelector,
+     * can be undefined if range and positionDetaisl are set (i.e. in case of a new annotation)
+     */
+    model: Node;
+    ontology: Graph;
+
+    /**
+     * Should be set in case of a new annotation (i.e. when model is undefined).
+     */
+    range?: Range;
+
+    /**
+     * Should be set in case of a new annotation (i.e. when model is undefined).
+     */
+    positionDetails?: AnnotationPositionDetails;
+
+    /**
+     * Should be set in case of a new annotation (i.e. when model is undefined).
+     */
+    source?: Node;
+}
+
+export default class AnnotationEditView extends BaseAnnotationView {
+    ontology: Graph;
+    source: Node;
+    range: Range;
+    positionDetails: AnnotationPositionDetails;
+    preselection: Node;
+    metadataView: ItemMetadataView;
+    ontologyClassPicker: OntologyClassPickerView;
+    snippetView: SnippetView;
+    modelIsAnnotion: boolean;
+    selectedOntologyClass: Node;
+
+    snippetViewIsInDOM: boolean;
+    DOMMutationObserver: MutationObserver;
+
+    constructor(options: ViewOptions) {
+        super(options);
+    }
+
+    initialize(options: ViewOptions): this {
+        this.ontology = options.ontology;
+
+        if (options.range) {
+            this.source = options.source;
+            this.range = options.range;
+            this.positionDetails = options.positionDetails;
+            this.model = getAnonymousTextQuoteSelector(this.range);
+        }
+
+        this.modelIsAnnotion = isType(this.model, oa.Annotation);
+
+        if (this.modelIsAnnotion) {
+            this.listenTo(this, 'source', this.processSource);
+            this.listenTo(this, 'body:ontologyClass', this.processOntologyClass)
+            this.listenTo(this, 'textQuoteSelector', this.processTextQuoteSelector);
+            this.processModel(options.model);
+            this.listenTo(this.model, 'change', this.processModel);
+        }
+        else {
+            this.processTextQuoteSelector(this.model);
+            this.listenTo(this.model, 'change', this.processTextQuoteSelector);
+        }
+
+        const config = { attributes: true, childList: true, subtree: true };
+        this.DOMMutationObserver = new MutationObserver(this.onDOMMutation.bind(this));
+        this.DOMMutationObserver.observe(this.$el.get(0), config);
+        return this;
+    }
+
+    onDOMMutation(mutationsList, observer): this {
+        for (let mutation of mutationsList) {
+            if (mutation.type === 'childList' && $(mutation.target).hasClass('snippet-container')) {
+                this.snippetViewIsInDOM = !this.snippetViewIsInDOM;
+                this.snippetView.handleDOMMutation(this.snippetViewIsInDOM);
+            }
+        }
+        return this;
+    }
+
+    processModel(node: Node): this {
+        this.baseProcessModel(node);
+
+        if (isType(node, oa.Annotation)) {
+            this.metadataView = new ItemMetadataView({ model: this.model });
+            this.metadataView.render();
+            this.initOntologyClassPicker();
+        }
+
+        return this;
+    }
+
+    processSource(source: Node): this {
+        this.source = source;
+        return this;
+    }
+
+    processTextQuoteSelector(selector: Node): this {
+        if (this.snippetView) return;
+
+        this.snippetView = new SnippetView({
+            selector: selector
+        });
+        this.snippetView.render();
+
+        if (!this.modelIsAnnotion) this.initOntologyClassPicker();
+        return this;
+    }
+
+    processOntologyClass(ontologyClass: Node): this {
+        this.preselection = ontologyClass;
+        return this;
+    }
+
+    initOntologyClassPicker(): this {
+        this.ontologyClassPicker = new OntologyClassPickerView({
+            collection: this.ontology,
+            preselection: this.preselection
+        });
+
+        this.ontologyClassPicker.render();
+        this.listenTo(this.ontologyClassPicker, 'select', this.onOntologyItemSelected);
+        return this;
+    }
+
+    render(): this {
+        this.ontologyClassPicker.$el.detach();
+        if (this.snippetView) this.snippetView.$el.detach();
+        if (this.metadataView) this.metadataView.$el.detach();
+
+        this.$el.html(this.template(this));
+        if (this.preselection) this.select(this.preselection);
+
+        this.$(".anno-edit-form").submit(function (e) { e.preventDefault(); })
+        this.$(".anno-edit-form").validate({
+            errorClass: "help is-danger",
+            ignore: "",
+        });
+
+        this.$('.ontology-class-picker-container').append(this.ontologyClassPicker.el);
+        if (this.snippetView) this.$('.snippet-container').append(this.snippetView.el);
+        if (this.metadataView) this.$('.metadata-container').append(this.metadataView.el);
+        return this;
+    }
+
+    submit(): this {
+        if (this.model.isNew()) {
+            composeAnnotation(
+                this.source,
+                this.positionDetails,
+                this.selectedOntologyClass,
+                this.snippetView.selector,
+                (error, results) => {
+                    if (error) return console.debug(error);
+                    this.trigger('annotationEditView:saveNew', this, results.annotation, results.items);
+                });
+        }
+        else {
+            let existingBodyOntologyClass = this.model.get(oa.hasBody);
+            if (existingBodyOntologyClass) this.model.unset(oa.hasBody, existingBodyOntologyClass);
+            this.model.set(oa.hasBody, (this.selectedOntologyClass));
+            this.model.save();
+            this.trigger('annotationEditView:save', this, this.model);
+        }
+        return this;
+    }
+
+    reset(): this {
+        this.model.previousAttributes();
+        // this.ontologyClassPicker.render();
+        this.trigger('reset');
+        return this;
+    }
+
+    select(item: Node): this {
+        this.$('.hidden-input').val(item.id).valid();
+        this.selectedOntologyClass = item;
+        return this;
+    }
+
+    onOntologyItemSelected(item: Node): this {
+        this.select(item);
+        return this;
+    }
+
+    onSaveClicked(event: JQueryEventObject): this {
+        event.preventDefault();
+        if (this.$(".anno-edit-form").valid()) {
+            this.submit();
+        }
+        return this;
+    }
+
+    onCancelClicked(event: JQueryEventObject): this {
+        event.preventDefault();
+        this.reset();
+        this.trigger('annotationEditView:close', this);
+        return this;
+    }
+
+    onRelatedItemsClicked(event: JQueryEventObject): this {
+        this.trigger('add-related-item', this.ontologyClassPicker.getSelected());
+        return this;
+    }
+}
+extend(AnnotationEditView.prototype, {
+    tagName: 'div',
+    className: 'annotation-edit-panel explorer-panel',
+    template: annotationEditTemplate,
+    events: {
+        'click .btn-save': 'onSaveClicked',
+        'click .btn-cancel': 'onCancelClicked',
+        'click .btn-rel-items': 'onRelatedItemsClicked',
+    }
+});

--- a/frontend/src/utilities/annotation/annotation-creation-utilities.ts
+++ b/frontend/src/utilities/annotation/annotation-creation-utilities.ts
@@ -1,0 +1,195 @@
+import * as _ from 'lodash';
+import * as a$ from 'async';
+
+import Node  from './../../jsonld/node';
+import { oa, vocab, rdf, xsd, staff, dcterms, } from './../../jsonld/ns';
+
+import ItemGraph from './../../utilities/item-graph';
+import { AnnotationPositionDetails } from './annotation-utilities';
+
+const prefixLength = 100;
+const suffixLength = 100;
+
+/**
+ * Get an instance of oa:TextQuoteSelector that is not synced to the backend,
+ * and doesn't have an @id. Ideal for passing a user selection('s Range) to
+ * the AnnotationEditView.
+ */
+export function getAnonymousTextQuoteSelector(range: Range): Node {
+    let prefix = getPrefix(range);
+    let suffix = getSuffix(range);
+
+    let tqs = new Node({
+        '@type': [oa.TextQuoteSelector],
+        [oa.exact]: [
+            {
+                "@value": range.toString()
+            }
+        ]
+    });
+
+    if (prefix) tqs.set(oa.prefix, prefix);
+    if (suffix) tqs.set(oa.suffix, suffix);
+    return tqs;
+}
+
+function getPrefix(exactRange: Range): string {
+    let startCharacterIndex = exactRange.startOffset - prefixLength;
+    if (startCharacterIndex < 0) startCharacterIndex = 0;
+    let prefixRange = document.createRange();
+    prefixRange.setStart(exactRange.startContainer, startCharacterIndex);
+    prefixRange.setEnd(exactRange.startContainer, exactRange.startOffset);
+    let result = prefixRange.toString();
+    prefixRange.detach();
+    return result;
+}
+
+function getSuffix(exactRange: Range): string {
+    let endCharacterIndex = exactRange.endOffset + suffixLength;
+    if (endCharacterIndex > exactRange.endContainer.textContent.length) {
+        endCharacterIndex = exactRange.endContainer.textContent.length;
+    }
+    let suffixRange = document.createRange();
+    suffixRange.setStart(exactRange.endContainer, exactRange.endOffset);
+    suffixRange.setEnd(exactRange.endContainer, endCharacterIndex);
+    let result = suffixRange.toString();
+    suffixRange.detach();
+    return result;
+}
+
+
+export function composeAnnotation(source: Node, posDetails: AnnotationPositionDetails, ontoClass: Node, tQSelector: Node, done?) {
+    const { startNodeIndex, startCharacterIndex, endNodeIndex, endCharacterIndex } = posDetails;
+
+    const inputs = {
+        startNodeIndex, startCharacterIndex, endNodeIndex, endCharacterIndex,
+        source, ontoClass, tQSelector, items: new ItemGraph(),
+    };
+
+    const tasks = {
+        startSelector: ['items', 'startNodeIndex', 'startCharacterIndex',
+            createXPathSelector,
+        ],
+        endSelector: ['items', 'endNodeIndex', 'endCharacterIndex', 'startSelector',
+            createEndSelector,
+        ],
+        rangeSelector: ['items', 'startSelector', 'endSelector',
+            createRangeSelector,
+        ],
+        textQuoteSelector: ['items', 'tQSelector', 'rangeSelector',
+            createTextQuoteSelector,
+        ],
+        specificResource: ['items', 'source', 'rangeSelector', 'textQuoteSelector',
+            createSpecificResource,
+        ],
+        // instance: ['items', 'ontoClass',
+        //     createOntologyInstance
+        // ],
+        annotation: ['items', 'specificResource', 'ontoClass',
+            createAnnotation,
+        ],
+    };
+    return a$.autoInject(combineAutoHash(inputs, tasks), done);
+}
+
+function combineAutoHash(inputs, tasks) {
+    const asyncifiedInputs = _.mapValues(inputs, constant => [a$.constant(constant)]);
+    return _.extend(asyncifiedInputs, tasks);
+}
+
+function unshiftArgs(callback) {
+    return _.partial(callback, null);
+}
+
+function watchEvent(emitter, name, transformCb = _.identity) {
+    return (done) => emitter.once(name, (...args) => {
+        transformCb(done)(...args)
+    });
+}
+
+function awaitEvent(success, error?, getVal = unshiftArgs, getErr?) {
+    return function(emitter, done) {
+        const tasks = [watchEvent(emitter, success, <any>getVal)];
+        if (error) tasks.push(watchEvent(emitter, error, getErr));
+        return a$.race(tasks, done);
+    }
+}
+
+function errorFromXHR(callback) {
+    return (_, xhr, options) => {
+        callback(options.error);
+    }
+}
+
+function createItem(items: ItemGraph, attributes: any, done?) {
+    return a$.waterfall([
+        a$.constant(items.create(attributes)),
+        awaitEvent('sync', 'error', unshiftArgs, errorFromXHR),
+    ], (error, results) => done(error, results));
+}
+
+// This is here for when linking to an item is implemented (but needs updating as well)
+function createOntologyInstance(items: ItemGraph, ontoClass: Node, done?) {
+    return;
+    const attributes = {
+        '@type': ontoClass.id,
+        // [skos.prefLabel]: getItemLabel(annotationText),
+        [dcterms.created]: [
+            {
+                "@type": xsd.dateTime,
+                "@value": "2085-12-31T04:33:16+0100"
+            }
+        ],
+        [dcterms.creator]: [
+            {
+                "@id": staff('JdeKruif')
+            }
+        ],
+    }
+    return createItem(items, attributes, done);
+}
+
+function createTextQuoteSelector(items: ItemGraph, textQuoteSelector: Node, rangeSelector, done?) {
+    return createItem(items, textQuoteSelector.attributes, done);
+}
+
+function createEndSelector(items: ItemGraph, container, offset, startSelector, done?) {
+    createXPathSelector(items,  container, offset, done);
+}
+
+function createXPathSelector(items: ItemGraph, container, offset, done?) {
+    const xPath = `substring(.//*[${container}]/text(), ${offset})`;
+    const attributes = {
+        '@type': oa.XPathSelector,
+        [rdf.value]: xPath,
+    };
+
+    return createItem(items, attributes, done);
+}
+
+function createRangeSelector(items: ItemGraph, start, end, done?) {
+    const attributes = {
+        '@type': vocab('RangeSelector'),
+        [oa.hasStartSelector]: start,
+        [oa.hasEndSelector]: end,
+    };
+    return createItem(items, attributes, done);
+}
+
+function createSpecificResource(items: ItemGraph, source, rangeSelector, textQuoteSelector, done?) {
+    const attributes = {
+        '@type': oa.SpecificResource,
+        [oa.hasSource]: source,
+        [oa.hasSelector]: [rangeSelector, textQuoteSelector],
+    };
+    return createItem(items, attributes, done);
+}
+
+function createAnnotation(items, specificResource, ontoClass, done?) {
+    const attributes = {
+        '@type': oa.Annotation,
+        [oa.hasBody]: [ontoClass],
+        [oa.hasTarget]: specificResource,
+    };
+    return createItem(items, attributes, done);
+}

--- a/frontend/src/utilities/item-metadata/item-metadata-template.hbs
+++ b/frontend/src/utilities/item-metadata/item-metadata-template.hbs
@@ -1,0 +1,24 @@
+<article class="accordion has-mt-10">
+    <div class="accordion-header toggle">
+        <p>{{title}}</p>
+        <button class="toggleProxy" aria-label="toggle"></button>
+    </div>
+    <div class="accordion-body">
+        <table class="accordion-content table is-bordered">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each metadata}}
+                <tr>
+                    <td>{{@key}}</td>
+                    <td>{{this}}</td>
+                </tr>
+                {{/each}}
+            </tbody>
+        </table>
+    </div>
+</article>

--- a/frontend/src/utilities/item-metadata/item-metadata-view.ts
+++ b/frontend/src/utilities/item-metadata/item-metadata-view.ts
@@ -1,0 +1,68 @@
+import { ViewOptions as BaseOpt } from 'backbone';
+import { extend } from 'lodash';
+import View from '../../core/view';
+
+import Node from '../../jsonld/node';
+
+import itemMetadataTemplate from './item-metadata-template';
+
+import { dcterms } from './../../jsonld/ns';
+import { getLabel } from './../../utilities/utilities';
+
+import * as bulmaAccordion from 'bulma-accordion';
+
+export interface ViewOptions extends BaseOpt<Node> {
+    model: Node;
+    /**
+     * Optional. Title of the accordion containing the metadata.
+     * Defaults to 'Item metadata'.
+     */
+    title?: string;
+}
+
+export default class ItemMetadataView extends View<Node> {
+    title: string;
+    metadata: Object;
+
+    constructor(options?: ViewOptions) {
+        super(options);
+    }
+
+    initialize(options: ViewOptions): this {
+        this.title = 'Item metadata';
+        if (options.title) this.title = options.title;
+        this.metadata = new Object();
+        this.collectDetails();
+        return this;
+    }
+
+    render(): this {
+        this.$el.html(this.template(this));
+        this.initAccordions();
+        return this;
+    }
+
+    collectDetails(): this {
+        if (this.model.has(dcterms.creator)) {
+            this.metadata['creator'] = getLabel(this.model.get(dcterms.creator)[0] as Node);
+        }
+        if (this.model.has(dcterms.created)) {
+            this.metadata['created'] = this.model.get(dcterms.created)[0];
+        }
+        return this;
+    }
+
+    initAccordions(): this {
+        this.$('.accordion').each(function (i, accordion) {
+            new bulmaAccordion(accordion);
+        });
+        return this;
+    }
+}
+extend(ItemMetadataView.prototype, {
+    tagName: 'div',
+    className: 'item-metadata accordions',
+    template: itemMetadataTemplate,
+    events: {
+    }
+});

--- a/frontend/src/utilities/ontology-class-picker/ontology-class-picker-item-view.ts
+++ b/frontend/src/utilities/ontology-class-picker/ontology-class-picker-item-view.ts
@@ -1,0 +1,48 @@
+import { ViewOptions as BaseOpt } from 'backbone';
+import { extend, sortBy } from 'lodash';
+import View from '../../core/view';
+
+import Node from '../../jsonld/node';
+import  LabelView from './../label-view';
+
+export interface ViewOptions extends BaseOpt<Node> {
+    model: Node;
+}
+
+export default class OntologyClassPickerItemView extends View<Node> {
+    labelView: LabelView;
+
+    initialize(options: ViewOptions): this {
+        this.labelView = new LabelView({ model: options.model, toolTipSetting: false });
+        return this;
+    }
+
+    render(): this {
+        this.labelView.$el.detach();
+        this.labelView.render().$el.appendTo(this.$el);
+        return this;
+    }
+
+    activate(): this {
+        this.$el.addClass('is-active');
+        this.trigger('activated', this);
+        return this;
+    }
+
+    deactivate(): this {
+        this.$el.removeClass('is-active');
+        return this;
+    }
+
+    onClick(event: any): this {
+        this.trigger('click', this);
+        return this;
+    }
+}
+extend(OntologyClassPickerItemView.prototype, {
+    tagName: 'a',
+    className: 'dropdown-item',
+    events: {
+        'mousedown': 'onClick',
+    }
+});

--- a/frontend/src/utilities/ontology-class-picker/ontology-class-picker-template.hbs
+++ b/frontend/src/utilities/ontology-class-picker/ontology-class-picker-template.hbs
@@ -1,0 +1,17 @@
+<div class="dropdown">
+    <div class="dropdown-trigger">
+        <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+            <span class="dropdown-label">This is a
+                <span class="dropdown-label-tag">...</span>
+            </span>
+            <span class="icon is-small">
+                <i class="fas fa-angle-down" aria-hidden="true"></i>
+            </span>
+        </button>
+    </div>
+    <div class="dropdown-menu" id="dropdown-menu" role="menu">
+        <div class="dropdown-content">
+            {{! OntologyClassPickerItems will be inserted here }}
+        </div>
+    </div>
+</div>

--- a/frontend/src/utilities/ontology-class-picker/ontology-class-picker-view.ts
+++ b/frontend/src/utilities/ontology-class-picker/ontology-class-picker-view.ts
@@ -1,0 +1,120 @@
+import { ViewOptions as BaseOpt } from 'backbone';
+import { extend } from 'lodash';
+import View from '../../core/view';
+
+import Node from '../../jsonld/node';
+import Graph from '../../jsonld/graph';
+import LabelView from './../label-view';
+
+import OntologyClassPickerItemView from './ontology-class-picker-item-view';
+import ontologyClassPickerTemplate from './ontology-class-picker-template';
+
+export interface ViewOptions extends BaseOpt<Node> {
+    collection: Graph;
+    preselection?: Node;
+}
+
+export default class OntologyClassPickerView extends View<Node> {
+    dropdownItems: OntologyClassPickerItemView[];
+    selected: Node;
+    preselection: Node;
+    label: any;
+
+    constructor(options: ViewOptions) {
+        super(options);
+    }
+
+    initialize(options: ViewOptions): this {
+        if (!options.collection) throw new TypeError('collection cannot be null or undefined');
+        this.initDropdownItems();
+
+        let self = this;
+        $(document).click(function () {
+            self.hideDropdown();
+        });
+
+        this.preselection = options.preselection;
+        this.listenTo(this.preselection, 'change', this.processPreselection);
+        return this;
+    }
+
+    processPreselection(ontologyClass: Node): this {
+        this.preselection = ontologyClass;
+        this.render();
+        return this;
+    }
+
+    initDropdownItems(): this {
+        this.dropdownItems = [];
+        this.collection.each((node) => {
+            let view = new OntologyClassPickerItemView({ model: node as Node });
+            view.on('click', this.onItemClicked, this);
+            view.on('activated', this.onItemActivated, this);
+            this.dropdownItems.push(view);
+        });
+        return;
+    }
+
+    render(): this {
+        this.dropdownItems.forEach((item) => item.$el.detach());
+        this.$el.html(this.template(this));
+        this.dropdownItems.forEach((item) => item.render().$el.appendTo(this.$('.dropdown-content')));
+        if (this.preselection) this.select(this.preselection);
+        return this;
+    }
+
+    getSelected(): Node {
+        return this.selected || undefined;
+    }
+
+    select(newValue: Node) {
+        this.dropdownItems.forEach((item) => {
+            if (item.model === newValue) {
+                item.activate();
+                this.trigger('select', newValue);
+            }
+            else {
+                item.deactivate();
+            }
+        });
+    }
+
+    setLabel(node: Node): this {
+        let dropdownLabel = this.$('.dropdown-label-tag');
+        if (this.label) this.label.remove();
+        dropdownLabel.text('');
+        this.label = new LabelView({ model: node });
+        this.label.render().$el.appendTo(dropdownLabel);
+        return this;
+    }
+
+    hideDropdown(): this {
+        this.$('.dropdown').removeClass('is-active');
+        return this;
+    }
+
+    onClick(event: any): this {
+        this.$('.dropdown').toggleClass('is-active');
+        event.stopPropagation();
+        return this;
+    }
+
+    onItemClicked(view: OntologyClassPickerItemView): this {
+        this.select(view.model);
+        return this;
+    }
+
+    onItemActivated(view: OntologyClassPickerItemView): this {
+        this.selected = view.model;
+        this.setLabel(view.model);
+        return this;
+    }
+}
+extend(OntologyClassPickerView.prototype, {
+    tagName: 'div',
+    className: 'ontology-class-picker',
+    template: ontologyClassPickerTemplate,
+    events: {
+        'click': 'onClick',
+    }
+});


### PR DESCRIPTION
This is a new and clean version of #138. It basically implements the `AnnotationEditView` and its dependencies, including a `ItemMetadataView` and an `OntologyClassPickerView`. Nothing too shocking, but please have a look at my handling of the form: I am a bit unsure about that.

For completeness sake, I also added `annotation-creation-utilities.ts`, although it is up for rework in #150. A brief glance over this file should be enough for now, I think. 