### PR TITLE
Footer uses flexbox

### DIFF
--- a/frontend/src/index.hbs
+++ b/frontend/src/index.hbs
@@ -20,8 +20,8 @@
         <main id="main">
         </main>
         <div class="push"></div>
+        <footer class="footer"></footer>
     </div>
-    <footer class="footer"></footer>
     {{#libs}}
     <script src="{{{@root.nodeRoot}}}{{{path}}}"></script>
     {{/libs}}

--- a/frontend/src/style/defaults.sass
+++ b/frontend/src/style/defaults.sass
@@ -8,7 +8,6 @@ $sixth-color: #D7C0D0
 $seventh-color: #7A5C61 // a.k.a. Russett (pinkish brown)
 $eigth-color: #3A2E39 // a.k.a. Thunder (very dark brown)
 
-$footer-height: 105px
 $footer-text-color: #ccc
 $footer-background-color: $secondary-color
 

--- a/frontend/src/style/footer.sass
+++ b/frontend/src/style/footer.sass
@@ -1,7 +1,5 @@
 footer
     background-color: $footer-background-color
-    // position: absolute
-    height: $footer-height
     padding: 1em 1em !important
     bottom: 0
     left: 0

--- a/frontend/src/style/main.sass
+++ b/frontend/src/style/main.sass
@@ -22,16 +22,14 @@ html, body
 .wrapper
     min-height: 100%
     height: auto !important
-    height: 100%
-    margin: 0 auto (-$footer-height)
+    display: flex
+    flex-direction: column
 
 body
     width: 100%
 
 .push
-    // 133 is the height of the footer (got the number by testing manually)
-    // Note that the same number should be in the readit.ts aspect, in 'getViewportHeight'
-    // height: 105px
+    flex: 1
 
 .footer, .push
     clear: both


### PR DESCRIPTION
Seeing as other parts of the application use flexbox freely, I didn't see a reason not to make use of it, and get rid of hard-coded heights. Now bug #300 is resolved, with the drawback that the footer may only be visible when scrolling down in a small window. @JeltevanBoheemen , what do you think?