### PR TITLE
remove check for sourcePanel in map

### DIFF
--- a/frontend/src/explorer/explorer-event-controller.ts
+++ b/frontend/src/explorer/explorer-event-controller.ts
@@ -33,7 +33,6 @@ export default class ExplorerEventController {
 
     mapSourceAnnotationList: Map<SourceView, AnnotationListView> = new Map();
     mapAnnotationListSource: Map<AnnotationListView, SourceView> = new Map();
-    mapAnnotationEditSource: Map<AnnoEditView, SourceView> = new Map();
     mapAnnotationListAnnotationDetail: Map<AnnotationListView, LdItemView> = new Map();
 
     constructor(explorerView: ExplorerView) {
@@ -232,7 +231,6 @@ export default class ExplorerEventController {
             model: undefined,
             collection: sourceView.collection,
         });
-        this.mapAnnotationEditSource.set(annoEditView, sourceView);
 
         if (listView) {
             annoEditView['_listview'] = listView;


### PR DESCRIPTION
This branch is supposed to close #343. The code executed when the "cancel" button is clicked is very confusing indeed. Somehow it presupposes you have a reference to the sourcePanel to remove the overlay. I simplified the code such that it is the same behaviour as, e.g. `closeEditExternal`. This means that on clicking "cancel", the edit overlay is removed, nothing else.

I may be missing something though @jgonggrijp ? If not, I might remove the reference to the `mapAnnotationEditSource` as it may be a vestige of some earlier mechanism that's no longer used.

Also wonder in how far we would want any extra actions here, e.g. scrolling to the panel on which the cancel button was clicked, or popping until that window.