### PR TITLE
Drop readit:reading_testimony and its annotations

### DIFF
--- a/backend/ontology/mock-ontology.jsonld
+++ b/backend/ontology/mock-ontology.jsonld
@@ -379,26 +379,5 @@
             "@id": "http://readit.example/ontology/had_outcome"
         },
         "http://www.w3.org/2004/02/skos/core#prefLabel": "was outcome of"
-    },
-    {
-        "@id": "http://readit.example/ontology/reading_testimony",
-        "@type": [
-            "http://www.w3.org/2000/01/rdf-schema#Class"
-        ],
-        "http://www.w3.org/2004/02/skos/core#prefLabel": [
-            {
-                "@value": "Reading Testimony"
-            }
-        ],
-        "http://www.w3.org/2004/02/skos/core#definition": [
-            {
-                "@value": "This is the definition of reading testimony"
-            }
-        ],
-        "http://schema.org/color": [
-            {
-                "@value": "#ffcc99"
-            }
-        ]
     }
 ]

--- a/backend/ontology/rdf_migrations.py
+++ b/backend/ontology/rdf_migrations.py
@@ -9,6 +9,21 @@ from rdf.ns import *
 from items.graph import graph as item_graph
 
 CIDOC = Namespace('http://www.cidoc-crm.org/cidoc-crm/')
+DELETE_CLASS_ANNOS_UPDATE = '''
+DELETE {
+    ?annotation ?a ?b.
+    ?target ?c ?d.
+    ?selector ?e ?f.
+} WHERE {
+    ?annotation a oa:Annotation;
+                oa:hasBody ?body;
+                oa:hasTarget ?target;
+                ?a ?b.
+    ?target oa:hasSelector ?selector;
+            ?c ?d.
+    ?selector ?e ?f.
+}
+'''
 
 
 def replace_object(graph, before, after):
@@ -145,3 +160,11 @@ class Migration(RDFMigration):
             conjunctive.remove((s, p, o, c))
 
         delete_predicate(conjunctive, before_rev)
+
+    @on_remove(READIT.reading_testimony)
+    def delete_READIT_reading_testimony(self, actual, conjunctive):
+        item_graph().update(
+            DELETE_CLASS_ANNOS_UPDATE,
+            initNs={'oa': OA},
+            initBindings={'body': READIT.reading_testimony},
+        )


### PR DESCRIPTION
It (#241) was a temporary category from the outset, serving only to collect training data for @GuillaumeLNB's testimony detection model. Removing on his request, to reduce confusion for test annotators.

@JeltevanBoheemen This seemed to do the right thing on my local development data, but if you could double-check the update query, that would be great.