### PR TITLE
Serialize blanknodes to prevent triplestore lockup

### DIFF
--- a/backend/readit/settings.py
+++ b/backend/readit/settings.py
@@ -14,6 +14,8 @@ import os
 
 from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
 
+from sparql.utils import bnode_to_sparql
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -40,6 +42,7 @@ RDFLIB_STORE_PREFIX = 'http://localhost:3030/readit'
 RDFLIB_STORE = SPARQLUpdateStore(
     queryEndpoint='{}/query'.format(RDFLIB_STORE_PREFIX),
     update_endpoint='{}/update'.format(RDFLIB_STORE_PREFIX),
+    node_to_sparql=bnode_to_sparql,
 )
 
 # Application definition

--- a/backend/readit/test_settings.py
+++ b/backend/readit/test_settings.py
@@ -1,6 +1,7 @@
 import os.path as op
 
 from .settings import *
+from sparql.utils import bnode_to_sparql
 
 RDF_NAMESPACE_HOST = 'testserver'
 RDF_NAMESPACE_ROOT = 'http://{}/'.format(RDF_NAMESPACE_HOST)
@@ -9,6 +10,7 @@ RDFLIB_STORE_PREFIX = 'http://localhost:3030/readit-test'
 RDFLIB_STORE = SPARQLUpdateStore(
     queryEndpoint='{}/query'.format(RDFLIB_STORE_PREFIX),
     update_endpoint='{}/update'.format(RDFLIB_STORE_PREFIX),
+    node_to_sparql=bnode_to_sparql
 )
 
 INDEX_FILE_PATH = 'trivial.html'

--- a/backend/sparql/conftest.py
+++ b/backend/sparql/conftest.py
@@ -77,6 +77,16 @@ DELETE_FROM_QUERY = '''
     DELETE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }} WHERE {{ ?s ?p ?o ; my:meow "loud" }}
 '''.format(ns=NLP_ONTOLOGY_NS, graph=NLP_ONTOLOGY_NS)
 
+INSERT_BLANK_QUERY = '''
+    PREFIX ns1: <http://schema.org/>
+    INSERT DATA { 
+        []          a           ns1:Cat     ;
+                    ns1:color   "red"       .
+        []          a           ns1:Dog     ;
+                    ns1:color   "black"     .
+    }
+'''
+
 
 @pytest.fixture
 def triples():
@@ -113,7 +123,8 @@ def test_queries():
         'INSERT': INSERT_QUERY,
         'DELETE': DELETE_QUERY,
         'DELETE_DATA': DELETE_DATA_QUERY,
-        'DELETE_FROM': DELETE_FROM_QUERY
+        'DELETE_FROM': DELETE_FROM_QUERY,
+        'INSERT_BLANK': INSERT_BLANK_QUERY
     }
     return SimpleNamespace(**values)
 

--- a/backend/sparql/utils.py
+++ b/backend/sparql/utils.py
@@ -1,0 +1,9 @@
+from rdflib import BNode
+from rdflib.plugins.stores.sparqlstore import _node_to_sparql
+
+
+def bnode_to_sparql(node):
+    '''Serializes blank nodes from sparqlstore'''
+    if isinstance(node, BNode):
+        return '<bnode:%s>' % node
+    return _node_to_sparql(node)


### PR DESCRIPTION
This 'fixes' the blank node problem. Gives some weird results as we found out at the end of last year, but these should not be a problem.