### PR TITLE
Feature/es language other

### DIFF
--- a/backend/scripts/sources_to_elasticsearch.py
+++ b/backend/scripts/sources_to_elasticsearch.py
@@ -125,9 +125,7 @@ def remove_text_other():
     }
     print(es.update_by_query(
         body=update_body,
-        index=settings.ES_ALIASNAME,
-        conflicts='proceed'))
+        index=settings.ES_ALIASNAME))
     print(es.update_by_query(
         body=update_body_capitalized,
-        index=settings.ES_ALIASNAME,
-        conflicts='proceed'))
+        index=settings.ES_ALIASNAME))

--- a/backend/scripts/sources_to_elasticsearch.py
+++ b/backend/scripts/sources_to_elasticsearch.py
@@ -118,7 +118,17 @@ def remove_text_other():
             "exists": {"field": "text_other"}
         }
     }
-    return es.update_by_query(
+    update_body_capitalized = {
+        "script":  "ctx._source.remove('text_Other')",
+        "query": {
+            "exists": {"field": "text_Other"}
+        }
+    }
+    print(es.update_by_query(
         body=update_body,
         index=settings.ES_ALIASNAME,
-        conflicts='proceed')
+        conflicts='proceed'))
+    print(es.update_by_query(
+        body=update_body_capitalized,
+        index=settings.ES_ALIASNAME,
+        conflicts='proceed'))

--- a/backend/scripts/sources_to_elasticsearch.py
+++ b/backend/scripts/sources_to_elasticsearch.py
@@ -50,14 +50,13 @@ def text_to_index():
         language = resolve_language(language_object)
         with open(filename, 'r', encoding='utf8') as f:
             text = f.read()
-        es.index(settings.ES_ALIASNAME, {
-            **{
+        es.index(
+            settings.ES_ALIASNAME,
+            optional_localized({
                 'id': serial,
                 'language': language,
-                'text': text
-            },
-            **({'text_{}'.format(language): text} if language != 'other' else {})
-        })
+                'text': text})
+        )
 
 
 def title_author_to_index():

--- a/backend/scripts/sources_to_elasticsearch.py
+++ b/backend/scripts/sources_to_elasticsearch.py
@@ -51,10 +51,12 @@ def text_to_index():
         with open(filename, 'r', encoding='utf8') as f:
             text = f.read()
         es.index(settings.ES_ALIASNAME, {
-            'id': serial,
-            'language': language,
-            'text': text,
-            'text_{}'.format(language): text
+            **{
+                'id': serial,
+                'language': language,
+                'text': text
+            },
+            **({'text_{}'.format(language): text} if language != 'other' else {})
         })
 
 

--- a/backend/scripts/sources_to_elasticsearch.py
+++ b/backend/scripts/sources_to_elasticsearch.py
@@ -106,3 +106,19 @@ def resolve_language(input_language):
             return result
         else:
             return 'other'
+
+
+def remove_text_other():
+    '''Removes text_other field from elastic search index.
+    Returns query result to allow inspection of number of updated records.
+    '''
+    update_body = {
+        "script":  "ctx._source.remove('text_other')",
+        "query": {
+            "exists": {"field": "text_other"}
+        }
+    }
+    return es.update_by_query(
+        body=update_body,
+        index=settings.ES_ALIASNAME,
+        conflicts='proceed')

--- a/backend/sources/utils.py
+++ b/backend/sources/utils.py
@@ -1,3 +1,6 @@
+from typing import Dict
+
+
 TEXT_FILENAME_PATTERN = 'sources/{:0>8}.txt'
 
 
@@ -11,3 +14,13 @@ def get_media_filename(serial):
 
 def get_serial_from_subject(subject):
     return str(subject).split('/')[-1]
+
+
+def optional_localized(document: Dict) -> Dict:
+    '''Optionally adds text_<language> field to elasticsearch index
+    Skipped if language = 'other'
+    '''
+    language = document['language']
+    if language != 'other':
+        document['text_{}'.format(language)] = document['text']
+    return document

--- a/backend/sources/utils_test.py
+++ b/backend/sources/utils_test.py
@@ -1,0 +1,17 @@
+from sources.utils import optional_localized
+
+
+def test_optional_localized():
+    en = {
+        'id': 1,
+        'language': 'en',
+        'text': 'a couple of words'
+    }
+    other = {
+        'id': 2,
+        'language': 'other',
+        'text': 'par riječi'
+    }
+
+    assert optional_localized(en).get('text_en')
+    assert not optional_localized(other).get('text_other')

--- a/backend/sources/views.py
+++ b/backend/sources/views.py
@@ -317,12 +317,14 @@ class AddSource(RDFResourceView):
         xml_sanitized_text = invalid_xml_remove(raw_text)
         text = html.escape(xml_sanitized_text)
         es.index(settings.ES_ALIASNAME, {
-            'id': source_id,
-            'language': source_language,
-            'author': author,
-            'title': title,
-            'text': text,
-            'text_{}'.format(source_language): text
+            **{
+                'id': source_id,
+                'language': source_language,
+                'author': author,
+                'title': title,
+                'text': text,
+            },
+            **({'text_{}'.format(source_language): text} if source_language != 'other' else {})
         })
         return text
 

--- a/backend/sources/views.py
+++ b/backend/sources/views.py
@@ -35,7 +35,7 @@ from sparql.utils import invalid_xml_remove
 from . import namespace as ns
 from .constants import SOURCES_NS
 from .graph import graph as sources_graph
-from .utils import get_media_filename, get_serial_from_subject
+from .utils import get_media_filename, get_serial_from_subject, optional_localized
 from .models import SourcesCounter
 from .permissions import UploadSourcePermission, DeleteSourcePermission
 from .tasks import poll_automated_annotations
@@ -316,16 +316,15 @@ class AddSource(RDFResourceView):
         raw_text = str(source_file.read().decode('utf8'))
         xml_sanitized_text = invalid_xml_remove(raw_text)
         text = html.escape(xml_sanitized_text)
-        es.index(settings.ES_ALIASNAME, {
-            **{
+        es.index(
+            settings.ES_ALIASNAME,
+            optional_localized({
                 'id': source_id,
                 'language': source_language,
                 'author': author,
                 'title': title,
                 'text': text,
-            },
-            **({'text_{}'.format(source_language): text} if source_language != 'other' else {})
-        })
+            }))
         return text
 
     def is_valid(self, data):


### PR DESCRIPTION
Resolved #514:
- Provides a script to remove `text_other` and `text_Other` from existing document in the ES-index.
- Prevent new insertions of `text_other` in `AddSource`.
- For completion, also updated old ES script that created ES documents from `sources_graph`.

I have made a note to remind us of running the new script upon next release. 