### PR TITLE
My own annotations are my own!

### DIFF
--- a/frontend/src/common-adapters/flat-item-model-test.ts
+++ b/frontend/src/common-adapters/flat-item-model-test.ts
@@ -14,7 +14,7 @@ import mockNLP from '../mock-data/mock-nlp-ontology';
 import mockItems from '../mock-data/mock-items';
 
 import { skos, dcterms, oa, readit, nlp, item } from '../common-rdf/ns';
-import ldChannel from '../common-rdf/radio';
+import userChannel from '../common-user/user-radio';
 import { asNative } from '../common-rdf/conversion';
 import Node from '../common-rdf/node';
 import Graph from '../common-rdf/graph';
@@ -245,14 +245,14 @@ describe('FlatItem', function() {
         const items = getFullItems();
         const ontologyClass = new Node(contentClass);
         const userURI = (items.annotation.get(dcterms.creator)[0] as Node).id;
-        ldChannel.reply('current-user-uri', constant(userURI));
+        userChannel.reply('current-user-uri', constant(userURI));
         const flatAnno = new FlatItem(items.annotation);
         await completion(flatAnno);
         expect(flatAnno.get('isOwn')).toBe(true);
         const filterClasses = flatAnno.getFilterClasses();
         expect(filterClasses).not.toContain('rit-other-made');
         expect(filterClasses).toContain('rit-self-made');
-        ldChannel.stopReplying('current-user-uri');
+        userChannel.stopReplying('current-user-uri');
     });
 
     it('tracks the related class', async function() {

--- a/frontend/src/common-adapters/flat-item-model.ts
+++ b/frontend/src/common-adapters/flat-item-model.ts
@@ -3,6 +3,7 @@ import { noop, each, includes, throttle } from 'lodash';
 import Model from '../core/model';
 import { skos, dcterms, oa, item, vocab } from '../common-rdf/ns';
 import ldChannel from '../common-rdf/radio';
+import userChannel from '../common-user/user-radio';
 import Node from '../common-rdf/node';
 import {
     getLabel,
@@ -362,7 +363,7 @@ export default class FlatItem extends Model {
             this.set('isOwn', false);
             return;
         }
-        const userURI = ldChannel.request('current-user-uri');
+        const userURI = userChannel.request('current-user-uri');
         this.set('isOwn', creator.id === userURI);
     }
 


### PR DESCRIPTION
Fixes #524. The problem was not so much a mismatching selector as a mismatching radio channel: `FlatItem` still attempted to obtain the current user URI from the `ldChannel`, while the corresponding endpoint had moved to the `userChannel` in #501. This problem went undetected in the tests because the `FlatItem` tests were still mocking the endpoint on `ldChannel`.

Maybe this should be a hotfix? On the other hand, maybe it is not that urgent, with everyone being on holiday? Thoughts welcome.